### PR TITLE
Use `t` from Yojson instead of deprecated `json` type

### DIFF
--- a/lib/client.mli
+++ b/lib/client.mli
@@ -4,7 +4,7 @@ type t = {
   secure: bool;
   use_eu_endpoint: bool
 }
-type response = (Yojson.Safe.json, string) result
+type response = (Yojson.Safe.t, string) result
 
 (** Creates a new client.
 

--- a/textrazor.opam
+++ b/textrazor.opam
@@ -13,7 +13,7 @@ depends: [
   "lwt_ssl"
   "lwt_ppx"
   "cohttp-lwt-unix"
-  "yojson"
+  "yojson" {>= "1.6.0"}
   "ppx_deriving_yojson"
   "dune"{build}
   "alcotest"{with-test}


### PR DESCRIPTION
Yojson 2.0 is going to drop the `json` type altogether so this PR prepares compatibility with Yojson 2.0+